### PR TITLE
Fix `reference_search.rb` to handle arguments in `Encoding::UTF_8`

### DIFF
--- a/workflow/reference_search.rb
+++ b/workflow/reference_search.rb
@@ -1,3 +1,5 @@
+Encoding.default_external = Encoding::UTF_8
+
 ($LOAD_PATH << File.expand_path("..", __FILE__)).uniq!
 
 require "rubygems" unless defined? Gem
@@ -10,7 +12,7 @@ require "json"
 
 REFERENCE_CACHE_DURATION = 7200 # 2 hours
 
-REFERENCE_JS_URL = "http://developer.android.com/reference/lists.js";
+REFERENCE_JS_URL = "https://developer.android.com/reference/lists.js";
 XML_REFERENCE_JS_URL = "android-xml-ref.js"
 
 def reference_search(alfred, query)


### PR DESCRIPTION
This fixes the plugin to work in Alfred v2.8.4 (437) and resolves #1.

![image](https://cloud.githubusercontent.com/assets/2360095/15556784/b127f052-229d-11e6-8035-b110381093d5.png)

Changed:
- `Encoding.default_external = Encoding::UTF_8`
- Changed reference URL to use `https` to avoid redirect error
